### PR TITLE
new: auto chatreport confirm

### DIFF
--- a/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
+++ b/src/main/java/club/sk1er/hytilities/config/HytilitiesConfig.java
@@ -362,6 +362,13 @@ public class HytilitiesConfig extends Vigilant {
     public static boolean thankWatchdog;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Auto Chat Report Confirm",
+        description = "Automatically confirms chat reports.",
+        category = "Chat", subcategory = "Chat Report"
+    )
+    public static boolean autoChatReportConfirm;
+
+    @Property(
         type = PropertyType.SWITCH, name = "Guild Welcome Message",
         description = "Send a friendly welcome message when a player joins your guild.",
         category = "Chat", subcategory = "Guild"

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/ChatHandler.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/ChatHandler.java
@@ -55,6 +55,7 @@ public class ChatHandler {
         this.registerModule(new LevelupEvent());
         this.registerModule(new GuildWelcomer());
         this.registerModule(new ThankWatchdog());
+        this.registerModule(new AutoChatReportConfirm());
         this.registerModule(new AutoChatSwapper());
         this.registerModule(new AchievementEvent());
         this.registerModule(new ConnectedMessage());

--- a/src/main/java/club/sk1er/hytilities/handlers/chat/modules/triggers/AutoChatReportConfirm.java
+++ b/src/main/java/club/sk1er/hytilities/handlers/chat/modules/triggers/AutoChatReportConfirm.java
@@ -1,0 +1,46 @@
+/*
+ * Hytilities - Hypixel focused Quality of Life mod.
+ * Copyright (C) 2021  Sk1er LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package club.sk1er.hytilities.handlers.chat.modules.triggers;
+
+import club.sk1er.hytilities.config.HytilitiesConfig;
+import club.sk1er.hytilities.handlers.chat.ChatReceiveModule;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class AutoChatReportConfirm implements ChatReceiveModule {
+
+    @Override
+    public int getPriority() {
+        return 3;
+    }
+
+    @Override
+    public void onMessageReceived(@NotNull ClientChatReceivedEvent event) {
+        if (event.message.getUnformattedText().equals("Please type /report confirm to log your report for staff review.")) {
+            Minecraft.getMinecraft().thePlayer.sendChatMessage("/report confirm");
+            event.setCanceled(true);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return HytilitiesConfig.autoChatReportConfirm;
+    }
+}


### PR DESCRIPTION
was not merged on original hytils for the possibility of being abused. personally, i dont think it would make it that much easier to abuse since it's the same command every time and a simple double up arrow while in chat if spamming chat reports would get you to the confirm message, but its up to you ig